### PR TITLE
Hide scrollbar during group expansion animation

### DIFF
--- a/tabgroups.css
+++ b/tabgroups.css
@@ -312,7 +312,7 @@ tab-group:not(:has(tab:not([hidden]))) {
     &:not([collapsed]) {
       max-height: 500px !important;
       padding-top: 0;
-      overflow-y: auto !important;
+      overflow-y: hidden !important;
     }
 
     tab-group:has(tab[hidden]) {


### PR DESCRIPTION
Fixed: 
![CleanShot_2025-02-18_19-33-50](https://github.com/user-attachments/assets/82536536-0085-4bfc-8636-da0d9a41f3c0)
