### PR TITLE
Fix tab group icon row at top & fix targeting tab bounces up/down when releasing the dragging tab

### DIFF
--- a/tabgroups.css
+++ b/tabgroups.css
@@ -58,9 +58,13 @@ tab-group:not(:has(tab:not([hidden]))) {
 
     & .tab-group-label-container {
       flex: 0 0 auto !important;
+      position: sticky !important;
+      top: 0 !important;
+      z-index: 1000 !important;
       transform: none !important;
       --tab-group-color-pale: transparent !important;
       --tab-group-color: transparent !important;
+
       margin: 0 !important;
       padding: 0 !important;
       display: flex !important;
@@ -70,7 +74,6 @@ tab-group:not(:has(tab:not([hidden]))) {
       transition: transform 0.2s ease;
       transition: background-color 0.2s ease;
       width: 100% !important;
-      transform: translateY(25px);
       @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
         width: var(--tab-min-width) !important;
       }
@@ -199,7 +202,7 @@ tab-group:not(:has(tab:not([hidden]))) {
 
     &[collapsed] {
       max-height: 36px !important;
-      transition: max-height 0.5s ease;
+      transition: max-height 0.3s ease;
 
       & .tab-group-label-container {
         &::after {
@@ -313,8 +316,10 @@ tab-group:not(:has(tab:not([hidden]))) {
 
     /* Expand when NOT collapsed */
     &:not([collapsed]) {
+      max-height: 205px;
       padding-top: 0;
-      overflow-y: hidden !important;
+      overflow-y: auto !important;
+      transition: max-height 0.3s ease;
     }
 
     tab-group:has(tab[hidden]) {

--- a/tabgroups.css
+++ b/tabgroups.css
@@ -213,7 +213,6 @@ tab-group:not(:has(tab:not([hidden]))) {
       & tab {
         z-index: -1 !important;
         opacity: 0 !important;
-        transform: translateY(-25px);
       }
 
       & .tab-group-label-container > label::before {

--- a/tabgroups.css
+++ b/tabgroups.css
@@ -28,6 +28,8 @@ tab-group:not(:has(tab:not([hidden]))) {
 @media (-moz-bool-pref: "zen.tabs.vertical") {
   tab-group {
     /* Visual Hierarchy Improvements */
+    display: flex !important;
+    flex-direction: column !important;
     @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
       width: var(--tab-min-width) !important;
     }
@@ -55,6 +57,8 @@ tab-group:not(:has(tab:not([hidden]))) {
     overflow: hidden !important;
 
     & .tab-group-label-container {
+      flex: 0 0 auto !important;
+      transform: none !important;
       --tab-group-color-pale: transparent !important;
       --tab-group-color: transparent !important;
       margin: 0 !important;
@@ -150,10 +154,10 @@ tab-group:not(:has(tab:not([hidden]))) {
     }
 
     & tab {
+      flex: 1 1 auto !important;
       opacity: 1 !important;
       margin-left: 18px !important;
-      transition: font-size 0.15s, margin 0.3s, padding 0.3s, opacity 0.1s,
-        scale, 0.2s !important;
+      transition: font-size 0.15s, margin 0.3s, padding 0.3s, opacity 0.1s !important;
       transition-delay: 0.1s !important;
       overflow: visible !important;
       @media (-moz-bool-pref: "tab.groups.display-tab-range") {

--- a/tabgroups.css
+++ b/tabgroups.css
@@ -314,7 +314,6 @@ tab-group:not(:has(tab:not([hidden]))) {
 
     /* Expand when NOT collapsed */
     &:not([collapsed]) {
-      max-height: 500px !important;
       padding-top: 0;
       overflow-y: hidden !important;
     }


### PR DESCRIPTION
  - Fix two issues mentioned [here](https://github.com/Anoms12/Advanced-Tab-Groups/discussions/19#discussioncomment-12241712)
	Approaches:
	1. Use `flex-grow/shrink` to narrow the flexing behaviors of label row & regular tabs by not allowing transform on the group label container to fix its position at the top, leaving the regular tab flex as it is
	2. Remove `scale` that causes the targeting tab to bounce up or down (correlated to the moving direction of the dragging tab)

  - Fix glitching(first tab) when collapsing:
https://github.com/Ender-Wang/Advanced-Tab-Groups/commit/670a338a38e9635332866cc24c4fe111cf3787f8#commitcomment-152939726