### PR TITLE
fix: Prevent errors from pre-existing global variables

### DIFF
--- a/advanced-tab-groups.uc.js
+++ b/advanced-tab-groups.uc.js
@@ -6,7 +6,7 @@
 /* https://github.com/Anoms12/Advanced-Tab-Groups */
 /* ====== v3.3.0s ====== */
 
-const UC_API = ChromeUtils.importESModule("chrome://userchromejs/content/uc_api.sys.mjs");
+window.UC_API = ChromeUtils.importESModule("chrome://userchromejs/content/uc_api.sys.mjs");
 
 class AdvancedTabGroups {
   constructor() {


### PR DESCRIPTION
I provided the full description on Discord, but basically it just imports UC_API and doesn't fail by it existing in another mod.